### PR TITLE
Check win optimization

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,3 +3,6 @@ rustflags = ["-C", "target-cpu=native"]
 
 [env]
 CONST_RANDOM_SEED = "onoro"
+
+[alias]
+t = "test --quiet"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,7 +810,6 @@ dependencies = [
  "abstract_game",
  "algebra",
  "const-random",
- "googletest",
  "itertools 0.11.0",
  "onoro",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,6 @@ rand = "0.8"
 rayon = "1.7"
 criterion = "0.7.0"
 itertools = "0.14.0"
-rstest = "0.26.1"
-rstest_reuse = "0.7.0"
-googletest = "0.14.2"
 
 [profile.release]
 opt-level = 3
@@ -31,3 +28,8 @@ lto = "fat"
 [[bench]]
 name = "onoro"
 harness = false
+
+[dev-dependencies]
+googletest = "0.14.2"
+rstest = "0.26.1"
+rstest_reuse = "0.7.0"

--- a/benches/onoro.rs
+++ b/benches/onoro.rs
@@ -126,7 +126,15 @@ fn check_win(c: &mut Criterion) {
 
   let mut rng = StdRng::seed_from_u64(4324908);
 
-  let states = generate_random_states(N_GAMES, 18, &mut rng);
+  let mut states = generate_random_states(N_GAMES, 18, &mut rng);
+  // Make an extra move for half the games. Otherwise, it would be the same
+  // color's turn in every game.
+  for state in &mut states {
+    if rng.gen_bool(0.5) {
+      *state = random_playout(state.clone(), 1, &mut rng);
+    }
+  }
+
   group.bench_function("check win", |b| {
     b.iter(|| {
       for onoro in &states {

--- a/benches/onoro.rs
+++ b/benches/onoro.rs
@@ -5,7 +5,7 @@ use criterion::{
 };
 use itertools::Itertools;
 use onoro::Onoro;
-use onoro_impl::Onoro16;
+use onoro_impl::{benchmark_util::CheckWinBenchmark, Onoro16};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 
 fn random_playout<R: Rng>(mut onoro: Onoro16, num_moves: usize, rng: &mut R) -> Onoro16 {
@@ -115,5 +115,29 @@ fn find_moves_p2(c: &mut Criterion) {
   group.finish();
 }
 
-criterion_group!(onoro_benches, find_moves_p1, find_moves_p2);
+fn check_win(c: &mut Criterion) {
+  const N_GAMES: usize = 10_000;
+
+  let mut group = c.benchmark_group("check win");
+  group.throughput(Throughput::Elements(
+    (2 * Onoro16::pawns_per_player() * N_GAMES) as u64,
+  ));
+  group.measurement_time(Duration::from_secs(20));
+
+  let mut rng = StdRng::seed_from_u64(4324908);
+
+  let states = generate_random_states(N_GAMES, 18, &mut rng);
+  group.bench_function("check win", |b| {
+    b.iter(|| {
+      for onoro in &states {
+        for pawn in onoro.pawns() {
+          black_box(onoro.bench_check_win(pawn.pos.into()));
+        }
+      }
+    })
+  });
+  group.finish();
+}
+
+criterion_group!(onoro_benches, find_moves_p1, find_moves_p2, check_win);
 criterion_main!(onoro_benches);

--- a/benches/onoro.rs
+++ b/benches/onoro.rs
@@ -119,9 +119,7 @@ fn check_win(c: &mut Criterion) {
   const N_GAMES: usize = 10_000;
 
   let mut group = c.benchmark_group("check win");
-  group.throughput(Throughput::Elements(
-    (2 * Onoro16::pawns_per_player() * N_GAMES) as u64,
-  ));
+  group.throughput(Throughput::Elements(N_GAMES as u64));
   group.measurement_time(Duration::from_secs(20));
 
   let mut rng = StdRng::seed_from_u64(4324908);

--- a/cardinality_estimate/Cargo.lock
+++ b/cardinality_estimate/Cargo.lock
@@ -180,7 +180,6 @@ dependencies = [
  "abstract_game",
  "algebra",
  "const-random",
- "googletest",
  "itertools",
  "onoro",
  "rand 0.8.5",

--- a/onoro_impl/Cargo.lock
+++ b/onoro_impl/Cargo.lock
@@ -64,6 +64,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,6 +122,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "googletest"
@@ -95,6 +150,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+
+[[package]]
+name = "indexmap"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -157,8 +228,22 @@ dependencies = [
  "itertools",
  "onoro",
  "rand",
+ "rstest",
+ "rstest_reuse",
  "union_find",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "ppv-lite86"
@@ -167,6 +252,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -247,10 +341,77 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rstest_reuse"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a8fb4672e840a587a66fc577a5491375df51ddb88f2a2c2a792598c326fe14"
+dependencies = [
+ "quote",
+ "rand",
+ "syn",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+
+[[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "syn"
@@ -273,6 +434,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,6 +465,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "winnow"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "zerocopy"

--- a/onoro_impl/Cargo.toml
+++ b/onoro_impl/Cargo.toml
@@ -15,3 +15,7 @@ union_find = { path = "../union_find" }
 
 [build]
 rustflags = ["-C", "target-feature=+ssse3"]
+
+[dev-dependencies]
+rstest = "0.26.1"
+rstest_reuse = "0.7.0"

--- a/onoro_impl/Cargo.toml
+++ b/onoro_impl/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2024"
 abstract_game = { path = "../abstract_game" }
 algebra = { path = "../algebra" }
 const-random = "0.1"
-googletest = "0.14.2"
 itertools = "0.11"
 onoro = { path = "../onoro" }
 rand = "0.8"
@@ -17,5 +16,6 @@ union_find = { path = "../union_find" }
 rustflags = ["-C", "target-feature=+ssse3"]
 
 [dev-dependencies]
+googletest = "0.14.2"
 rstest = "0.26.1"
 rstest_reuse = "0.7.0"

--- a/onoro_impl/Cargo.toml
+++ b/onoro_impl/Cargo.toml
@@ -12,3 +12,6 @@ itertools = "0.11"
 onoro = { path = "../onoro" }
 rand = "0.8"
 union_find = { path = "../union_find" }
+
+[build]
+rustflags = ["-C", "target-feature=+ssse3"]

--- a/onoro_impl/src/benchmark_util.rs
+++ b/onoro_impl/src/benchmark_util.rs
@@ -1,0 +1,15 @@
+use onoro::hex_pos::HexPos;
+
+use crate::OnoroImpl;
+
+pub trait CheckWinBenchmark {
+  fn bench_check_win(&self, last_move: HexPos) -> bool;
+}
+
+impl<const N: usize, const N2: usize, const ADJ_CNT_SIZE: usize> CheckWinBenchmark
+  for OnoroImpl<N, N2, ADJ_CNT_SIZE>
+{
+  fn bench_check_win(&self, last_move: HexPos) -> bool {
+    self.check_win(last_move)
+  }
+}

--- a/onoro_impl/src/lib.rs
+++ b/onoro_impl/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod benchmark_util;
 mod canonicalize;
 mod const_rand;
 mod hash;

--- a/onoro_impl/src/onoro.rs
+++ b/onoro_impl/src/onoro.rs
@@ -385,7 +385,7 @@ impl<const N: usize, const N2: usize, const ADJ_CNT_SIZE: usize> OnoroImpl<N, N2
     const LSB_ONES: u64 = 0x0101_0101_0101_0101;
     const MSB_ONES: u64 = 0x8080_8080_8080_8080;
 
-    const IDX_OFFSET: u32 = 2;
+    const IDX_OFFSET: u32 = 1;
     const IDX_TRANSLATE: u64 = LSB_ONES * IDX_OFFSET as u64;
 
     const SELECT_X_MASK: u64 = 0x0f0f_0f0f_0f0f_0f0f;
@@ -442,7 +442,7 @@ impl<const N: usize, const N2: usize, const ADJ_CNT_SIZE: usize> OnoroImpl<N, N2
     let y_in_a_row = broadcast_to_bit_indices(x_equal_mask & pawns_y);
     let x_in_a_row = broadcast_to_bit_indices(y_equal_mask & pawns_x);
     let xy_in_a_row = broadcast_to_bit_indices(delta_equal_mask & pawns_x);
-    let all_in_a_row = x_in_a_row | (y_in_a_row << 19) | (xy_in_a_row << 38);
+    let all_in_a_row = x_in_a_row | (y_in_a_row << 18) | (xy_in_a_row << 36);
 
     // Check if any 4 bits in a row are set:
     let all_in_a_row = all_in_a_row & (all_in_a_row >> 1);

--- a/onoro_impl/src/onoro.rs
+++ b/onoro_impl/src/onoro.rs
@@ -432,7 +432,7 @@ impl<const N: usize, const N2: usize, const ADJ_CNT_SIZE: usize> OnoroImpl<N, N2
     let y_in_a_row = packed_positions_to_mask(x_equal_mask & pawns_y);
     let x_in_a_row = packed_positions_to_mask(y_equal_mask & pawns_x);
     let xy_in_a_row = packed_positions_to_mask(delta_equal_mask & pawns_x);
-    let all_in_a_row = x_in_a_row | (y_in_a_row << 16) | (xy_in_a_row << 32);
+    let all_in_a_row = x_in_a_row | (y_in_a_row << 17) | (xy_in_a_row << 34);
 
     // Check if any 4 bits in a row are set:
     let all_in_a_row = all_in_a_row & (all_in_a_row >> 1);

--- a/onoro_impl/src/onoro.rs
+++ b/onoro_impl/src/onoro.rs
@@ -432,7 +432,7 @@ impl<const N: usize, const N2: usize, const ADJ_CNT_SIZE: usize> OnoroImpl<N, N2
     let y_in_a_row = packed_positions_to_mask(x_equal_mask & pawns_y);
     let x_in_a_row = packed_positions_to_mask(y_equal_mask & pawns_x);
     let xy_in_a_row = packed_positions_to_mask(delta_equal_mask & pawns_x);
-    let all_in_a_row = x_in_a_row | (y_in_a_row << 17) | (xy_in_a_row << 34);
+    let all_in_a_row = x_in_a_row | (y_in_a_row << 16) | (xy_in_a_row << 32);
 
     // Check if any 4 bits in a row are set:
     let all_in_a_row = all_in_a_row & (all_in_a_row >> 1);

--- a/onoro_impl/src/onoro.rs
+++ b/onoro_impl/src/onoro.rs
@@ -406,12 +406,8 @@ impl<const N: usize, const N2: usize, const ADJ_CNT_SIZE: usize> OnoroImpl<N, N2
     };
 
     let low_positions = align_to_mask(&pawn_poses[0..8]);
-    let low_positions = (low_positions | (low_positions >> 24)) & 0x00000000_ffffffff;
-
     let hi_positions = align_to_mask(&pawn_poses[8..16]);
-    let hi_positions = (hi_positions | (hi_positions << 40)) & 0xffffffff_00000000;
-
-    let all_pawns = low_positions | hi_positions;
+    let all_pawns = low_positions | (hi_positions << 8);
 
     let pawns_x = all_pawns & SELECT_X_MASK;
     let pawns_y = (all_pawns >> 4) & SELECT_X_MASK;

--- a/onoro_impl/src/onoro.rs
+++ b/onoro_impl/src/onoro.rs
@@ -437,7 +437,7 @@ impl<const N: usize, const N2: usize, const ADJ_CNT_SIZE: usize> OnoroImpl<N, N2
     let y_in_a_row = broadcast_to_bit_indices(x_equal_mask & pawns_y);
     let x_in_a_row = broadcast_to_bit_indices(y_equal_mask & pawns_x);
     let xy_in_a_row = broadcast_to_bit_indices(delta_equal_mask & pawns_x);
-    let all_in_a_row = x_in_a_row | (y_in_a_row << 17) | (xy_in_a_row << 34);
+    let all_in_a_row = x_in_a_row | (y_in_a_row << 19) | (xy_in_a_row << 38);
 
     // Check if any 4 bits in a row are set:
     let all_in_a_row = all_in_a_row & (all_in_a_row >> 1);

--- a/onoro_impl/src/onoro.rs
+++ b/onoro_impl/src/onoro.rs
@@ -379,7 +379,7 @@ impl<const N: usize, const N2: usize, const ADJ_CNT_SIZE: usize> OnoroImpl<N, N2
     offset
   }
 
-  fn check_win(&self, last_move: HexPos) -> bool {
+  pub(crate) fn check_win(&self, last_move: HexPos) -> bool {
     // Bitvector of positions occupied by pawns of this color along the 3 lines
     // extending out from last_move. Intentionally leave a zero bit between each
     // of the 3 sets so they can't form a continuous string of 1's across

--- a/onoro_impl/src/packed_idx.rs
+++ b/onoro_impl/src/packed_idx.rs
@@ -1,11 +1,14 @@
-use std::{fmt::Display, num::Wrapping};
+use std::{
+  fmt::{Debug, Display},
+  num::Wrapping,
+};
 
 use onoro::{
   OnoroIndex,
   hex_pos::{HexPos, HexPosOffset},
 };
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct PackedIdx {
   bytes: Wrapping<u8>,
 }
@@ -108,6 +111,12 @@ impl std::ops::AddAssign<IdxOffset> for PackedIdx {
 impl Display for PackedIdx {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     write!(f, "({}, {})", self.x(), self.y())
+  }
+}
+
+impl Debug for PackedIdx {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{self}")
   }
 }
 

--- a/onoro_impl/src/util.rs
+++ b/onoro_impl/src/util.rs
@@ -1,6 +1,6 @@
 use core::arch::x86_64::{_mm_set_epi8, _mm_shuffle_epi8};
 use std::arch::x86_64::{
-  _mm_cvtsi128_si64x, _mm_set_epi64x, _mm_unpackhi_epi64, _mm_unpacklo_epi8,
+  _mm_cmpeq_epi8, _mm_cvtsi128_si64x, _mm_set_epi64x, _mm_unpackhi_epi64, _mm_unpacklo_epi8,
 };
 
 use itertools::Itertools;
@@ -41,12 +41,31 @@ define_cmp!(max_i16, min_i16, i16);
 define_cmp!(max_i32, min_i32, i32);
 define_cmp!(max_i64, min_i64, i64);
 
-/// Given a `u8`, returns a `u64` with each byte of the `u64` equal to the
-/// passed `u8`.
 #[inline]
-pub const fn broadcast_u8_to_u64(v: u8) -> u64 {
+#[target_feature(enable = "ssse3")]
+unsafe fn broadcast_u8_to_u64_sse3(v: u8) -> u64 {
+  let v = v as i8;
+  let mask = _mm_set_epi8(0, 0, 0, 0, 0, 0, 0, 0, v, v, v, v, v, v, v, v);
+  _mm_cvtsi128_si64x(mask) as u64
+}
+
+#[cfg(any(test, not(target_feature = "ssse3")))]
+#[inline]
+pub const fn broadcast_u8_to_u64_slow(v: u8) -> u64 {
   const BYTE_ANCHOR: u64 = 0x0101_0101_0101_0101;
   (v as u64) * BYTE_ANCHOR
+}
+
+/// Given a `u8`, returns a `u64` with each byte of the `u64` equal to the
+/// passed `u8`.
+#[inline(always)]
+pub fn broadcast_u8_to_u64(v: u8) -> u64 {
+  #[cfg(target_feature = "ssse3")]
+  unsafe {
+    broadcast_u8_to_u64_sse3(v)
+  }
+  #[cfg(not(target_feature = "ssse3"))]
+  broadcast_u8_to_u64_slow(v)
 }
 
 #[inline]
@@ -118,12 +137,68 @@ pub fn packed_positions_to_mask(packed_positions: u64) -> u64 {
   packed_positions_to_mask_slow(packed_positions)
 }
 
+#[inline]
+#[target_feature(enable = "ssse3")]
+unsafe fn equal_mask_epi8_sse3(byte_vec: u64, needle: u8) -> u64 {
+  let b = needle as i8;
+  let needle_mask = _mm_set_epi8(0, 0, 0, 0, 0, 0, 0, 0, b, b, b, b, b, b, b, b);
+  let byte_vec = _mm_set_epi64x(byte_vec as i64, byte_vec as i64);
+
+  let equal_mask = _mm_cmpeq_epi8(needle_mask, byte_vec);
+  _mm_cvtsi128_si64x(equal_mask) as u64
+}
+
+#[cfg(any(test, not(target_feature = "ssse3")))]
+#[inline]
+fn equal_mask_epi8_slow(byte_vec: u64, needle: u8) -> u64 {
+  byte_vec
+    .to_ne_bytes()
+    .into_iter()
+    .map(|byte| if byte == needle { 0xff } else { 0 })
+    .enumerate()
+    .fold(0, |mask, (i, byte)| mask | (byte << (i * 8)))
+}
+
+/// bitmask of 0xff in byte if that byte = needle in byte_vec, 0 otherwise
+#[inline(always)]
+pub fn equal_mask_epi8(byte_vec: u64, needle: u8) -> u64 {
+  #[cfg(target_feature = "ssse3")]
+  unsafe {
+    equal_mask_epi8_sse3(byte_vec, needle)
+  }
+  #[cfg(not(target_feature = "ssse3"))]
+  equal_mask_epi8_slow(byte_vec, needle)
+}
+
 #[cfg(test)]
 mod tests {
   use rstest::rstest;
   use rstest_reuse::{apply, template};
 
-  use crate::util::{packed_positions_to_mask, packed_positions_to_mask_slow};
+  use crate::util::{
+    broadcast_u8_to_u64, broadcast_u8_to_u64_slow, equal_mask_epi8, equal_mask_epi8_slow,
+    packed_positions_to_mask, packed_positions_to_mask_slow,
+  };
+
+  #[template]
+  #[rstest]
+  fn broadcast_u8_to_u64(
+    #[values(broadcast_u8_to_u64, broadcast_u8_to_u64_slow)] broadcast: impl FnOnce(u8) -> u64,
+    #[values(
+      (0x12, 0x12_12_12_12_12_12_12_12),
+      (0x00, 0x00_00_00_00_00_00_00_00),
+      (0xff, 0xff_ff_ff_ff_ff_ff_ff_ff),
+    )]
+    args: (u8, u64),
+  ) {
+  }
+
+  #[apply(broadcast_u8_to_u64)]
+  #[test]
+  fn test_broadcast_u8_to_u64(broadcast: impl FnOnce(u8) -> u64, args: (u8, u64)) {
+    let (input, expected) = args;
+    assert_eq!(broadcast(input), expected);
+  }
 
   #[template]
   #[rstest]
@@ -144,5 +219,24 @@ mod tests {
   fn test_packed_positions_to_mask(packed_positions: impl FnOnce(u64) -> u64, args: (u64, u64)) {
     let (input, expected) = args;
     assert_eq!(packed_positions(input), expected);
+  }
+
+  #[template]
+  #[rstest]
+  fn equal_mask_epi8(
+    #[values(equal_mask_epi8, equal_mask_epi8_slow)] equal_mask: impl FnOnce(u64, u8) -> u64,
+    #[values(
+      (0x01_02_03_04_05_06_07_08, 0x03, 0x00_00_ff_00_00_00_00_00),
+      (0xaa_bb_aa_bb_bb_aa_bb_aa, 0xaa, 0xff_00_ff_00_00_ff_00_ff),
+    )]
+    args: (u64, u8, u64),
+  ) {
+  }
+
+  #[apply(equal_mask_epi8)]
+  #[test]
+  fn test_equal_mask_epi8(equal_mask: impl FnOnce(u64, u8) -> u64, args: (u64, u8, u64)) {
+    let (byte_vec, needle, expected) = args;
+    assert_eq!(equal_mask(byte_vec, needle), expected);
   }
 }

--- a/onoro_impl/src/util.rs
+++ b/onoro_impl/src/util.rs
@@ -1,3 +1,8 @@
+use core::arch::x86_64::{__m128i, _mm_set_epi8, _mm_shuffle_epi8};
+use std::arch::x86_64::{_mm_cvtsi128_si64x, _mm_set_epi64x};
+
+use itertools::Itertools;
+
 #[inline]
 pub const fn unreachable() -> ! {
   #[cfg(debug_assertions)]
@@ -40,4 +45,96 @@ define_cmp!(max_i64, min_i64, i64);
 pub const fn broadcast_u8_to_u64(v: u8) -> u64 {
   const BYTE_ANCHOR: u64 = 0x0101_0101_0101_0101;
   (v as u64) * BYTE_ANCHOR
+}
+
+/// Given 8 byte values packed into a u64, returns a u64 with each
+/// corresponding bit index set for each byte (1-indexed). Zero byte values are
+/// ignored. All non-zero bytes must be unique.
+#[target_feature(enable = "ssse3")]
+unsafe fn packed_positions_to_mask_sse3(packed_positions: u64) -> u64 {
+  debug_assert!(
+    packed_positions
+      .to_ne_bytes()
+      .into_iter()
+      .all(|byte| byte < 0x10)
+  );
+  debug_assert!(
+    packed_positions
+      .to_ne_bytes()
+      .into_iter()
+      .filter(|&byte| byte != 0)
+      .all_unique()
+  );
+
+  let lo_data = _mm_set_epi8(
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0x80u8 as i8,
+    0x40,
+    0x20,
+    0x10,
+    0x08,
+    0x04,
+    0x02,
+    0x01,
+    0,
+  );
+  let hi_data = _mm_set_epi8(
+    0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  );
+
+  let shuffle_mask = _mm_set_epi64x(0, packed_positions as i64);
+  let lo_masks = _mm_shuffle_epi8(lo_data, shuffle_mask);
+  let hi_masks = _mm_shuffle_epi8(hi_data, shuffle_mask);
+
+  let lo_masks = _mm_cvtsi128_si64x(lo_masks) as u64;
+  let hi_masks = _mm_cvtsi128_si64x(hi_masks) as u64;
+
+  let lo_masks = (lo_masks | (lo_masks >> 8)) & 0x00ff_00ff_00ff_00ff;
+  let hi_masks = (hi_masks | (hi_masks << 8)) & 0xff00_ff00_ff00_ff00;
+  let masks = lo_masks | hi_masks;
+
+  let masks = masks | (masks >> 16);
+  let masks = masks | (masks >> 32);
+  masks & 0x0000_0000_0000_ffff
+}
+
+#[cfg(any(test, not(target_feature = "ssse3")))]
+fn packed_positions_to_mask_slow(packed_positions: u64) -> u64 {
+  packed_positions
+    .to_ne_bytes()
+    .into_iter()
+    .filter(|&byte| byte != 0)
+    .fold(0, |mask, byte| mask | (1u64 << (byte - 1)))
+}
+
+pub fn packed_positions_to_mask(packed_positions: u64) -> u64 {
+  #[cfg(target_feature = "ssse3")]
+  unsafe {
+    packed_positions_to_mask_sse3(packed_positions)
+  }
+  #[cfg(not(target_feature = "ssse3"))]
+  packed_positions_to_mask_slow(packed_positions)
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::util::{packed_positions_to_mask, packed_positions_to_mask_slow};
+
+  #[test]
+  fn test_packed_positions_to_mask() {
+    assert_eq!(packed_positions_to_mask(0x0102030405060708), 0xff);
+    assert_eq!(packed_positions_to_mask(0x01040506070a0c0e), 0x2a79);
+  }
+
+  #[test]
+  fn test_packed_positions_to_mask_slow() {
+    assert_eq!(packed_positions_to_mask_slow(0x0102030405060708), 0xff);
+    assert_eq!(packed_positions_to_mask_slow(0x01040506070a0c0e), 0x2a79);
+  }
 }

--- a/onoro_impl/src/util.rs
+++ b/onoro_impl/src/util.rs
@@ -74,7 +74,7 @@ unsafe fn packed_positions_to_mask_sse3(packed_positions: u64) -> u64 {
   //
   // Since the range of bytes we support is 0 - 15, we need 2 bytes to
   // represent (1 << (index - 1)) for all possible indices. The size of entries
-  // in the lookup table is 8 bytes, so we have two lookup tables, one holding
+  // in the lookup table is 1 byte, so we have two lookup tables, one holding
   // the lower half of the masks and one holding the upper half.
   #[rustfmt::skip]
   let lo_data = _mm_set_epi8(
@@ -124,9 +124,9 @@ fn packed_positions_to_mask_slow(packed_positions: u64) -> u64 {
     .fold(0, |mask, byte| mask | (1u64 << (byte - 1)))
 }
 
-/// Given 8 byte values packed into a u64, returns a u64 with each
-/// corresponding bit index set for each byte (1-indexed). Zero byte values are
-/// ignored. All non-zero bytes must be unique.
+/// Returns a u64 with bits set in the positions indicated by the byte values
+/// in `packed_positions`, minus 1. Zero byte values are ignored. All non-zero
+/// bytes must be unique.
 #[inline(always)]
 pub fn packed_positions_to_mask(packed_positions: u64) -> u64 {
   #[cfg(target_feature = "ssse3")]

--- a/onoro_impl/src/util.rs
+++ b/onoro_impl/src/util.rs
@@ -1,5 +1,7 @@
 use core::arch::x86_64::{_mm_set_epi8, _mm_shuffle_epi8};
-use std::arch::x86_64::{_mm_cvtsi128_si64x, _mm_hadd_epi16, _mm_set_epi64x, _mm_unpacklo_epi8};
+use std::arch::x86_64::{
+  _mm_cvtsi128_si64x, _mm_set_epi64x, _mm_unpackhi_epi64, _mm_unpacklo_epi8,
+};
 
 use itertools::Itertools;
 
@@ -81,11 +83,12 @@ unsafe fn packed_positions_to_mask_sse3(packed_positions: u64) -> u64 {
   let lo_masks = _mm_shuffle_epi8(lo_data, shuffle_mask);
   let hi_masks = _mm_shuffle_epi8(hi_data, shuffle_mask);
 
-  let zero = _mm_set_epi64x(0, 0);
-
   let masks = _mm_unpacklo_epi8(lo_masks, hi_masks);
-  let masks = _mm_hadd_epi16(masks, zero);
-  let masks = _mm_cvtsi128_si64x(masks) as u64;
+
+  let lo_masks = _mm_cvtsi128_si64x(masks) as u64;
+  let masks = _mm_unpackhi_epi64(masks, masks);
+  let hi_masks = _mm_cvtsi128_si64x(masks) as u64;
+  let masks = lo_masks + hi_masks;
 
   let masks = masks + (masks >> 16);
   let masks = masks + (masks >> 32);

--- a/tests/exploration_test.rs
+++ b/tests/exploration_test.rs
@@ -74,9 +74,27 @@ fn test_random_exploration<T: OnoroFactory, U: OnoroFactory>(
   let mut rng = StdRng::seed_from_u64(seed);
 
   for _ in 0..MAX_ITERS {
-    assert_eq!(onoro1.in_phase1(), onoro2.in_phase1());
-    assert_eq!(onoro1.finished(), onoro2.finished());
-    assert_eq!(onoro1.pawns_in_play(), onoro2.pawns_in_play());
+    println!("{:?}", onoro1);
+    for pawn in onoro1.pawns() {
+      use onoro::OnoroPawn;
+
+      println!("{:?}", pawn.pos());
+    }
+    assert_eq!(
+      onoro1.in_phase1(),
+      onoro2.in_phase1(),
+      "In position:\n{onoro1:?}"
+    );
+    assert_eq!(
+      onoro1.finished(),
+      onoro2.finished(),
+      "In position:\n{onoro1:?}"
+    );
+    assert_eq!(
+      onoro1.pawns_in_play(),
+      onoro2.pawns_in_play(),
+      "In position:\n{onoro1:?}"
+    );
 
     if onoro1.finished().is_some() {
       return Ok(());


### PR DESCRIPTION
This version uses bit twiddling and x86 SSE intrinsics to operate on all positions at once, which make this function a lot smaller (codegen wise, not lines of code lol). 

```
check win/check win     time:   [616.22 µs 616.26 µs 616.30 µs]
                        thrpt:  [16.226 Melem/s 16.227 Melem/s 16.228 Melem/s]
                 change:
                        time:   [−48.458% −48.387% −48.336%] (p = 0.00 < 0.05)
                        thrpt:  [+93.560% +93.751% +94.016%]
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) high mild
  7 (7.00%) high severe
```