### PR TITLE
Dynamic basis selection for minimum bounding parallelogram

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ target
 *.s
 *.svg
 *.swp
-output.txt
+*.txt

--- a/onoro/src/onoro.rs
+++ b/onoro/src/onoro.rs
@@ -5,7 +5,7 @@ use itertools::interleave;
 use crate::{
   error::{OnoroError, OnoroResult},
   hex_pos::HexPosOffset,
-  onoro_util::{BoardLayoutPawns, pawns_from_board_string},
+  onoro_util::{pawns_from_board_string, BoardLayoutPawns},
 };
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -67,6 +67,12 @@ pub trait OnoroIndex: Clone + Copy + Eq + Debug {
       Self::from_coords((self.x() + 1) as u32, (self.y() + 1) as u32),
     ]
     .into_iter()
+  }
+
+  fn axial_distance(&self, other: Self) -> u32 {
+    let dx = self.x() - other.x();
+    let dy = self.y() - other.y();
+    (dx.abs() + dy.abs() + (dx - dy).abs()) as u32 / 2
   }
 }
 
@@ -259,12 +265,10 @@ pub trait Onoro: Sized {
     for i in 0..(n_pawns - 1) / 2 {
       pawns.swap(2 * i + 1, n_pawns.div_ceil(2) + i);
     }
-    debug_assert!(
-      pawns
-        .iter()
-        .enumerate()
-        .all(|(idx, (_, color))| { (idx % 2 == 0) == matches!(color, PawnColor::Black) })
-    );
+    debug_assert!(pawns
+      .iter()
+      .enumerate()
+      .all(|(idx, (_, color))| { (idx % 2 == 0) == matches!(color, PawnColor::Black) }));
 
     Ok(Self::from_indexes(pawns.into_iter().map(|(pos, _)| {
       Self::Index::from_coords((pos.x() - min_x + 1) as u32, (pos.y() - min_y + 1) as u32)

--- a/onoro/src/onoro.rs
+++ b/onoro/src/onoro.rs
@@ -69,6 +69,9 @@ pub trait OnoroIndex: Clone + Copy + Eq + Debug {
     .into_iter()
   }
 
+  /// The distance between two hex tiles on the infinite hexagonal plane,
+  /// measured by the minimum number of tiles you would need to cross to get
+  /// from one to the other.
   fn axial_distance(&self, other: Self) -> u32 {
     let dx = self.x() - other.x();
     let dy = self.y() - other.y();

--- a/onoro/src/onoro.rs
+++ b/onoro/src/onoro.rs
@@ -77,6 +77,15 @@ pub trait OnoroIndex: Clone + Copy + Eq + Debug {
     let dy = self.y() - other.y();
     (dx.abs() + dy.abs() + (dx - dy).abs()) as u32 / 2
   }
+
+  /// Returns the area of the minimum bounding parallelogram containing both of
+  /// these points.
+  fn minimum_bounding_parallelogram_area(&self, other: Self) -> u64 {
+    let dx = (self.x() - other.x()).unsigned_abs() as u64 + 1;
+    let dy = (self.y() - other.y()).unsigned_abs() as u64 + 1;
+    let dxy = ((self.y() - self.x()) - (other.y() - other.x())).unsigned_abs() as u64 + 1;
+    dx * dy * dxy / dx.max(dy).max(dxy)
+  }
 }
 
 impl OnoroIndex for (i32, i32) {

--- a/onoro_impl/src/board_vec_indexer.rs
+++ b/onoro_impl/src/board_vec_indexer.rs
@@ -1,0 +1,242 @@
+use num_traits::PrimInt;
+use onoro::hex_pos::HexPos;
+
+use crate::{
+  FilterNullPackedIdx, PackedIdx,
+  util::{CoordLimits, MinAndMax},
+};
+
+/// The choice of basis to use for the minimum bounding parallelogram of the
+/// pawns on the board. In the diagrams below, x is the first coordinate axis,
+/// and y is the second. A `-` sign in front of the axis label means the arrow
+/// is pointing in the negative direction.
+#[derive(Clone, Copy)]
+pub enum Basis {
+  ///```text
+  /// +y
+  /// Γ
+  ///  \
+  ///   \
+  ///    +---> +x
+  ///```
+  XvY,
+  ///```text
+  ///    +x
+  ///    7
+  ///   /
+  ///  /
+  /// +---> -y
+  ///```
+  XvXY,
+  ///```text
+  /// -x    +y
+  /// Γ     7
+  ///  \   /
+  ///   \ /
+  ///    +
+  ///```
+  XYvY,
+}
+
+pub struct DetermineBasisOutput {
+  pub basis: Basis,
+  pub corner: HexPos,
+  pub width: u8,
+  pub use_u128: bool,
+}
+
+pub fn determine_basis<const N: usize>(coord_limits: CoordLimits) -> DetermineBasisOutput {
+  let x = coord_limits.x();
+  let y = coord_limits.y();
+  let xy = coord_limits.xy();
+
+  let dx = x.delta();
+  let dy = y.delta();
+  let dxy = xy.delta();
+
+  let build_output =
+    |basis: Basis, corner: HexPos, coord1: MinAndMax<u32>, coord2: MinAndMax<u32>| {
+      DetermineBasisOutput {
+        basis,
+        corner,
+        width: (coord1.delta() + 3) as u8,
+        // We will represent the board with a bitvector, where each bit corresponds
+        // to a tile and is set if there is a pawn there. We want a 1-tile padding
+        // around the perimeter so we can also represent the neighbor candidates
+        // with a bitvec.
+        use_u128: (coord1.delta() + 3) * (coord2.delta() + 3) > u64::BITS,
+      }
+    };
+
+  let max = dx.max(dy).max(dxy);
+  if dxy == max {
+    let x_y_corner = HexPos::new(x.min() - 1, y.min() - 1);
+    build_output(Basis::XvY, x_y_corner, x, y)
+  } else if dy == max {
+    let xy_y_corner = HexPos::new(
+      x.min() - 1,
+      x.min() + xy.max() - PackedIdx::xy_offset::<N>(),
+    );
+    build_output(Basis::XYvY, xy_y_corner, xy, x)
+  } else {
+    debug_assert_eq!(dx, max);
+    let x_xy_corner = HexPos::new(
+      y.min() + PackedIdx::xy_offset::<N>() - xy.min(),
+      y.min() - 1,
+    );
+    build_output(Basis::XvXY, x_xy_corner, y, xy)
+  }
+}
+
+/// An indexing schema for mapping HexPos <-> bitvector index.
+pub struct BoardVecIndexer {
+  /// The basis that is used for indexing positions.
+  basis: Basis,
+  /// The corner of the minimal bounding box containing all placed pawns, with
+  /// a 1-tile perimeter of empty tiles.
+  corner: HexPos,
+  /// The width of this minimal bounding box.
+  width: u8,
+}
+
+impl BoardVecIndexer {
+  pub fn new(basis: Basis, corner: HexPos, width: u8) -> Self {
+    Self {
+      basis,
+      corner,
+      width,
+    }
+  }
+
+  const fn coords(&self, pos: PackedIdx) -> (u32, u32) {
+    let x = pos.x();
+    let y = pos.y();
+    let cx = self.corner.x();
+    let cy = self.corner.y();
+    match self.basis {
+      Basis::XvY => (x - cx, y - cy),
+      Basis::XvXY => (y - cy, y + cx - x - cy),
+      Basis::XYvY => (x + cy - y - cx, x - cx),
+    }
+  }
+
+  const fn pos_from_coords(&self, coords: (u32, u32)) -> PackedIdx {
+    let (x, y) = coords;
+    let cx = self.corner.x();
+    let cy = self.corner.y();
+    match self.basis {
+      Basis::XvY => PackedIdx::new(x + cx, y + cy),
+      Basis::XvXY => PackedIdx::new(x + cx - y, x + cy),
+      Basis::XYvY => PackedIdx::new(y + cx, y + cy - x),
+    }
+  }
+
+  /// Maps a `PackedIdx` from the Onoro state to an index in the board bitvec.
+  pub fn index(&self, pos: PackedIdx) -> usize {
+    let (c1, c2) = self.coords(pos);
+    debug_assert!(c1 < self.width as u32);
+    c2 as usize * self.width as usize + c1 as usize
+  }
+
+  /// Maps an index from the board bitvec to a `PackedIdx` in the Onoro state.
+  pub fn pos_from_index(&self, index: u32) -> PackedIdx {
+    debug_assert!((3..=16).contains(&self.width));
+    let c1 = index % self.width as u32;
+    let c2 = index / self.width as u32;
+    self.pos_from_coords((c1, c2))
+  }
+
+  /// Builds both the board bitvec and neighbor candidates. The board bitvec
+  /// has a 1 in each index corresponding to an occupied tile, and the neighbor
+  /// candidates have a 1 in each index corresponding to an empty neighbor of
+  /// any pawn.
+  pub fn build_bitvecs<I: PrimInt>(&self, pawn_poses: &[PackedIdx]) -> (I, I) {
+    let width = self.width as usize;
+
+    let board = pawn_poses
+      .iter()
+      .filter_null()
+      .fold(I::zero(), |board_vec, &pos| {
+        let index = self.index(pos);
+        debug_assert!(index > width);
+        board_vec | (I::one() << index)
+      });
+
+    // All neighbors are -(width+1), -width, -1, +1, +width, +(width+1) in
+    // index space.
+    let neighbor_candidates = (board >> (width + 1))
+      | (board >> width)
+      | (board >> 1)
+      | (board << 1)
+      | (board << width)
+      | (board << (width + 1));
+
+    (board, neighbor_candidates & !board)
+  }
+
+  /// Constructs a mask of the 6 neighbors of a tile at the given bitvector
+  /// index.
+  pub fn neighbors_mask<I: PrimInt>(&self, index: usize) -> I {
+    let lesser_neighbors_mask = unsafe { I::from(0x3 | (0x1 << self.width)).unwrap_unchecked() };
+    let greater_neighbors_mask = unsafe { I::from(0x2 | (0x3 << self.width)).unwrap_unchecked() };
+
+    let lesser_neighbors = (lesser_neighbors_mask << index) >> (self.width as usize + 1);
+    let greater_neighbors = greater_neighbors_mask << index;
+
+    lesser_neighbors | greater_neighbors
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use onoro::OnoroIndex;
+
+  use crate::{PackedIdx, util::packed_positions_coord_limits};
+
+  use super::*;
+
+  #[test]
+  fn test_determine_basis() {
+    const N: u32 = 16;
+    for y1 in 1..(N - 1) {
+      for x1 in 1..(N - 1) {
+        let p1 = PackedIdx::new(x1, y1);
+        for y2 in 1..(N - 1) {
+          for x2 in 1..(N - 1) {
+            if x1 == x2 && y1 == y2 {
+              continue;
+            }
+            let p2 = PackedIdx::new(x2, y2);
+            if p1.axial_distance(p2) > N - 3 {
+              // These two points are farther apart than any two pawns could be.
+              continue;
+            }
+
+            let mut coord_poses = [PackedIdx::null(); N as usize];
+            coord_poses[0] = p1;
+            coord_poses[1] = p2;
+            let coord_limits = packed_positions_coord_limits(&coord_poses);
+
+            let DetermineBasisOutput {
+              basis,
+              corner,
+              width,
+              use_u128,
+            } = determine_basis::<{ N as usize }>(coord_limits);
+            let indexer = BoardVecIndexer::new(basis, corner, width);
+
+            assert!(indexer.index(p1) > width as usize);
+            assert!(
+              indexer.index(p1)
+                < if use_u128 { u128::BITS } else { u64::BITS } as usize - width as usize
+            );
+            assert!(
+              indexer.index(p2)
+                < if use_u128 { u128::BITS } else { u64::BITS } as usize - width as usize
+            );
+          }
+        }
+      }
+    }
+  }
+}

--- a/onoro_impl/src/lib.rs
+++ b/onoro_impl/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod benchmark_util;
+mod board_vec_indexer;
 mod canonicalize;
 mod const_rand;
 mod hash;

--- a/onoro_impl/src/p1_move_gen.rs
+++ b/onoro_impl/src/p1_move_gen.rs
@@ -114,14 +114,14 @@ impl BoardVecIndexer {
     }
   }
 
-  const fn offset_from_coords(&self, coords: (u32, u32)) -> PackedIdx {
+  const fn pos_from_coords(&self, coords: (u32, u32)) -> PackedIdx {
     let (x, y) = coords;
     let cx = self.corner.x();
     let cy = self.corner.y();
     match self.basis {
       Basis::XvY => PackedIdx::new(x + cx, y + cy),
       Basis::XvXY => PackedIdx::new(x + cx - y, x + cy),
-      Basis::XYvY => PackedIdx::new(y + cx, x + cy - y),
+      Basis::XYvY => PackedIdx::new(y + cx, y + cy - x),
     }
   }
 
@@ -137,7 +137,7 @@ impl BoardVecIndexer {
     debug_assert!((3..=16).contains(&self.width));
     let c1 = index % self.width as u32;
     let c2 = index / self.width as u32;
-    self.offset_from_coords((c1, c2))
+    self.pos_from_coords((c1, c2))
   }
 
   /// Builds both the board bitvec and neighbor candidates. The board bitvec

--- a/onoro_impl/src/p1_move_gen.rs
+++ b/onoro_impl/src/p1_move_gen.rs
@@ -277,8 +277,8 @@ enum ImplContainer {
   /// including a 1-tile padding around the perimeter. This is much faster to
   /// operate on than a u128.
   Small(Impl<u64>),
-  /// We need to support any board size. The largest possible board is 8 x 8
-  /// (see test_worst_case below), which, with a 1-tile padding, requires 81
+  /// We need to support any board size. The largest possible board is 8 x 9
+  /// (see test_worst_case below), which, with a 1-tile padding, requires 110
   /// bits for the board bitvec.
   Large(Box<Impl<u128>>),
 }
@@ -455,6 +455,10 @@ mod tests {
               indexer.index(p1)
                 < if use_u128 { u128::BITS } else { u64::BITS } as usize - width as usize
             );
+            assert!(
+              indexer.index(p2)
+                < if use_u128 { u128::BITS } else { u64::BITS } as usize - width as usize
+            );
           }
         }
       }
@@ -475,16 +479,6 @@ mod tests {
   #[apply(test_build)]
   #[rstest]
   fn test_build_board_vec(onoro: Onoro16) {
-    let move_gen = P1MoveGenerator::new(&onoro);
-    let indexer = &move_gen.indexer();
-    let board_vec = build_board_vec(onoro.pawn_poses(), indexer);
-
-    assert_eq!(get_board_vec(&move_gen), board_vec);
-  }
-
-  #[test]
-  fn test_build_board_vec2() {
-    let onoro = Onoro16::default_start();
     let move_gen = P1MoveGenerator::new(&onoro);
     let indexer = &move_gen.indexer();
     let board_vec = build_board_vec(onoro.pawn_poses(), indexer);
@@ -532,21 +526,21 @@ mod tests {
 
   #[test]
   fn test_line_x() -> OnoroResult {
-    let worst_case = Onoro16::from_board_string(
+    let line_x = Onoro16::from_board_string(
       ". B . . . . . . . . . . . .
         W B W B W B W B W B W B W B
          . . . . . . . . . . . . W .",
     )?;
 
-    let move_gen = P1MoveGenerator::new(&worst_case);
-    assert_eq!(move_gen.to_iter(&worst_case).count(), 26);
+    let move_gen = P1MoveGenerator::new(&line_x);
+    assert_eq!(move_gen.to_iter(&line_x).count(), 26);
 
     Ok(())
   }
 
   #[test]
   fn test_line_y() -> OnoroResult {
-    let worst_case = Onoro16::from_board_string(
+    let line_y = Onoro16::from_board_string(
       ". B .
         W B .
          . W .
@@ -563,15 +557,15 @@ mod tests {
                     . W .",
     )?;
 
-    let move_gen = P1MoveGenerator::new(&worst_case);
-    assert_eq!(move_gen.to_iter(&worst_case).count(), 26);
+    let move_gen = P1MoveGenerator::new(&line_y);
+    assert_eq!(move_gen.to_iter(&line_y).count(), 26);
 
     Ok(())
   }
 
   #[test]
   fn test_line_xy() -> OnoroResult {
-    let worst_case = Onoro16::from_board_string(
+    let line_xy = Onoro16::from_board_string(
       ". . . . . . . . . . . . W B
         . . . . . . . . . . . . W .
          . . . . . . . . . . . B . .
@@ -588,8 +582,8 @@ mod tests {
                     B W . . . . . . . . . . . .",
     )?;
 
-    let move_gen = P1MoveGenerator::new(&worst_case);
-    assert_eq!(move_gen.to_iter(&worst_case).count(), 26);
+    let move_gen = P1MoveGenerator::new(&line_xy);
+    assert_eq!(move_gen.to_iter(&line_xy).count(), 26);
 
     Ok(())
   }

--- a/onoro_impl/src/p1_move_gen.rs
+++ b/onoro_impl/src/p1_move_gen.rs
@@ -3,190 +3,10 @@ use num_traits::{PrimInt, Unsigned};
 use onoro::hex_pos::HexPos;
 
 use crate::{
-  FilterNullPackedIdx, Move, OnoroImpl, PackedIdx,
-  util::{CoordLimits, MinAndMax, likely, packed_positions_coord_limits},
+  Move, OnoroImpl, PackedIdx,
+  board_vec_indexer::{Basis, BoardVecIndexer, DetermineBasisOutput, determine_basis},
+  util::{likely, packed_positions_coord_limits},
 };
-
-/// The choice of basis to use for the minimum bounding parallelogram of the
-/// pawns on the board. In the diagrams below, x is the first coordinate axis,
-/// and y is the second. A `-` sign in front of the axis label means the arrow
-/// is pointing in the negative direction.
-#[derive(Clone, Copy)]
-enum Basis {
-  ///```text
-  /// +y
-  /// Γ
-  ///  \
-  ///   \
-  ///    +---> +x
-  ///```
-  XvY,
-  ///```text
-  ///    +x
-  ///    7
-  ///   /
-  ///  /
-  /// +---> -y
-  ///```
-  XvXY,
-  ///```text
-  /// -x    +y
-  /// Γ     7
-  ///  \   /
-  ///   \ /
-  ///    +
-  ///```
-  XYvY,
-}
-
-struct DetermineBasisOutput {
-  basis: Basis,
-  corner: HexPos,
-  width: u8,
-  use_u128: bool,
-}
-
-fn determine_basis<const N: usize>(coord_limits: CoordLimits) -> DetermineBasisOutput {
-  let x = coord_limits.x();
-  let y = coord_limits.y();
-  let xy = coord_limits.xy();
-
-  let dx = x.delta();
-  let dy = y.delta();
-  let dxy = xy.delta();
-
-  let build_output =
-    |basis: Basis, corner: HexPos, coord1: MinAndMax<u32>, coord2: MinAndMax<u32>| {
-      DetermineBasisOutput {
-        basis,
-        corner,
-        width: (coord1.delta() + 3) as u8,
-        // We will represent the board with a bitvector, where each bit corresponds
-        // to a tile and is set if there is a pawn there. We want a 1-tile padding
-        // around the perimeter so we can also represent the neighbor candidates
-        // with a bitvec.
-        use_u128: (coord1.delta() + 3) * (coord2.delta() + 3) > u64::BITS,
-      }
-    };
-
-  let max = dx.max(dy).max(dxy);
-  if dxy == max {
-    let x_y_corner = HexPos::new(x.min() - 1, y.min() - 1);
-    build_output(Basis::XvY, x_y_corner, x, y)
-  } else if dy == max {
-    let xy_y_corner = HexPos::new(
-      x.min() - 1,
-      x.min() + xy.max() - PackedIdx::xy_offset::<N>(),
-    );
-    build_output(Basis::XYvY, xy_y_corner, xy, x)
-  } else {
-    debug_assert_eq!(dx, max);
-    let x_xy_corner = HexPos::new(
-      y.min() + PackedIdx::xy_offset::<N>() - xy.min(),
-      y.min() - 1,
-    );
-    build_output(Basis::XvXY, x_xy_corner, y, xy)
-  }
-}
-
-/// An indexing schema for mapping HexPos <-> bitvector index.
-struct BoardVecIndexer {
-  /// The basis that is used for indexing positions.
-  basis: Basis,
-  /// The corner of the minimal bounding box containing all placed pawns, with
-  /// a 1-tile perimeter of empty tiles.
-  corner: HexPos,
-  /// The width of this minimal bounding box.
-  width: u8,
-}
-
-impl BoardVecIndexer {
-  fn new(basis: Basis, corner: HexPos, width: u8) -> Self {
-    Self {
-      basis,
-      corner,
-      width,
-    }
-  }
-
-  const fn coords(&self, pos: PackedIdx) -> (u32, u32) {
-    let x = pos.x();
-    let y = pos.y();
-    let cx = self.corner.x();
-    let cy = self.corner.y();
-    match self.basis {
-      Basis::XvY => (x - cx, y - cy),
-      Basis::XvXY => (y - cy, y + cx - x - cy),
-      Basis::XYvY => (x + cy - y - cx, x - cx),
-    }
-  }
-
-  const fn pos_from_coords(&self, coords: (u32, u32)) -> PackedIdx {
-    let (x, y) = coords;
-    let cx = self.corner.x();
-    let cy = self.corner.y();
-    match self.basis {
-      Basis::XvY => PackedIdx::new(x + cx, y + cy),
-      Basis::XvXY => PackedIdx::new(x + cx - y, x + cy),
-      Basis::XYvY => PackedIdx::new(y + cx, y + cy - x),
-    }
-  }
-
-  /// Maps a `PackedIdx` from the Onoro state to an index in the board bitvec.
-  fn index(&self, pos: PackedIdx) -> usize {
-    let (c1, c2) = self.coords(pos);
-    debug_assert!(c1 < self.width as u32);
-    c2 as usize * self.width as usize + c1 as usize
-  }
-
-  /// Maps an index from the board bitvec to a `PackedIdx` in the Onoro state.
-  fn pos_from_index(&self, index: u32) -> PackedIdx {
-    debug_assert!((3..=16).contains(&self.width));
-    let c1 = index % self.width as u32;
-    let c2 = index / self.width as u32;
-    self.pos_from_coords((c1, c2))
-  }
-
-  /// Builds both the board bitvec and neighbor candidates. The board bitvec
-  /// has a 1 in each index corresponding to an occupied tile, and the neighbor
-  /// candidates have a 1 in each index corresponding to an empty neighbor of
-  /// any pawn.
-  fn build_bitvecs<I: PrimInt>(&self, pawn_poses: &[PackedIdx]) -> (I, I) {
-    let width = self.width as usize;
-
-    let board = pawn_poses
-      .iter()
-      .filter_null()
-      .fold(I::zero(), |board_vec, &pos| {
-        let index = self.index(pos);
-        debug_assert!(index > width);
-        board_vec | (I::one() << index)
-      });
-
-    // All neighbors are -(width+1), -width, -1, +1, +width, +(width+1) in
-    // index space.
-    let neighbor_candidates = (board >> (width + 1))
-      | (board >> width)
-      | (board >> 1)
-      | (board << 1)
-      | (board << width)
-      | (board << (width + 1));
-
-    (board, neighbor_candidates & !board)
-  }
-
-  /// Constructs a mask of the 6 neighbors of a tile at the given bitvector
-  /// index.
-  fn neighbors_mask<I: PrimInt>(&self, index: usize) -> I {
-    let lesser_neighbors_mask = unsafe { I::from(0x3 | (0x1 << self.width)).unwrap_unchecked() };
-    let greater_neighbors_mask = unsafe { I::from(0x2 | (0x3 << self.width)).unwrap_unchecked() };
-
-    let lesser_neighbors = (lesser_neighbors_mask << index) >> (self.width as usize + 1);
-    let greater_neighbors = greater_neighbors_mask << index;
-
-    lesser_neighbors | greater_neighbors
-  }
-}
 
 struct Impl<I> {
   /// A bitvector representation of the board, with bits set if there is a pawn
@@ -355,16 +175,13 @@ impl<const N: usize, const N2: usize, const ADJ_CNT_SIZE: usize> GameMoveIterato
 #[cfg(test)]
 mod tests {
   use abstract_game::GameMoveIterator;
-  use onoro::{Onoro, OnoroIndex, error::OnoroResult, hex_pos::HexPos, test_util::BOARD_POSITIONS};
+  use onoro::{Onoro, error::OnoroResult, hex_pos::HexPos, test_util::BOARD_POSITIONS};
   use rstest::rstest;
   use rstest_reuse::{apply, template};
 
   use crate::{
     FilterNullPackedIdx, Onoro16, PackedIdx,
-    p1_move_gen::{
-      BoardVecIndexer, DetermineBasisOutput, ImplContainer, P1MoveGenerator, determine_basis,
-    },
-    util::packed_positions_coord_limits,
+    p1_move_gen::{BoardVecIndexer, ImplContainer, P1MoveGenerator},
   };
 
   fn get_board_vec<const N: usize, const N2: usize, const ADJ_CNT_SIZE: usize>(
@@ -418,51 +235,6 @@ mod tests {
     }
 
     neighbors & !board_vec
-  }
-
-  #[test]
-  fn test_determine_basis() {
-    const N: u32 = 16;
-    for y1 in 1..(N - 1) {
-      for x1 in 1..(N - 1) {
-        let p1 = PackedIdx::new(x1, y1);
-        for y2 in 1..(N - 1) {
-          for x2 in 1..(N - 1) {
-            if x1 == x2 && y1 == y2 {
-              continue;
-            }
-            let p2 = PackedIdx::new(x2, y2);
-            if p1.axial_distance(p2) > N - 3 {
-              // These two points are farther apart than any two pawns could be.
-              continue;
-            }
-
-            let mut coord_poses = [PackedIdx::null(); N as usize];
-            coord_poses[0] = p1;
-            coord_poses[1] = p2;
-            let coord_limits = packed_positions_coord_limits(&coord_poses);
-
-            let DetermineBasisOutput {
-              basis,
-              corner,
-              width,
-              use_u128,
-            } = determine_basis::<{ N as usize }>(coord_limits);
-            let indexer = BoardVecIndexer::new(basis, corner, width);
-
-            assert!(indexer.index(p1) > width as usize);
-            assert!(
-              indexer.index(p1)
-                < if use_u128 { u128::BITS } else { u64::BITS } as usize - width as usize
-            );
-            assert!(
-              indexer.index(p2)
-                < if use_u128 { u128::BITS } else { u64::BITS } as usize - width as usize
-            );
-          }
-        }
-      }
-    }
   }
 
   #[template]

--- a/onoro_impl/src/p1_move_gen.rs
+++ b/onoro_impl/src/p1_move_gen.rs
@@ -7,23 +7,30 @@ use crate::{
   util::{CoordLimits, MinAndMax, likely, packed_positions_coord_limits},
 };
 
+/// The choice of basis to use for the minimum bounding parallelogram of the
+/// pawns on the board. In the diagrams below, x is the first coordinate axis,
+/// and y is the second. A `-` sign in front of the axis label means the arrow
+/// is pointing in the negative direction.
 #[derive(Clone, Copy)]
 enum Basis {
   ///```text
+  /// +y
   /// Γ
   ///  \
   ///   \
-  ///    +--->
+  ///    +---> +x
   ///```
   XvY,
   ///```text
+  ///    +x
   ///    7
   ///   /
   ///  /
-  /// +--->
+  /// +---> -y
   ///```
   XvXY,
   ///```text
+  /// -x    +y
   /// Γ     7
   ///  \   /
   ///   \ /

--- a/onoro_impl/src/packed_idx.rs
+++ b/onoro_impl/src/packed_idx.rs
@@ -15,6 +15,10 @@ pub struct PackedIdx {
 }
 
 impl PackedIdx {
+  pub const fn xy_offset<const N: usize>() -> u32 {
+    N as u32
+  }
+
   pub const fn new(x: u32, y: u32) -> Self {
     debug_assert!(x < 0x10);
     debug_assert!(y < 0x10);
@@ -37,6 +41,24 @@ impl PackedIdx {
 
   pub const fn y(&self) -> u32 {
     ((self.bytes.0 as u32) >> 4) & 0x0fu32
+  }
+
+  /// Returns the coordinate along the xy-axis, the angular bisector between
+  /// the x- and y-axes. This is normalized such that any PackedIdx will return
+  /// a positive value.
+  ///
+  ///```
+  /// (0,3)   (1,3)   (2,3)   (3,3)
+  ///   3       2       1       0
+  ///     (0,2)   (1,2)   (2,2)   (3,2)
+  ///       2       1       0      -1
+  ///         (0,1)   (1,1)   (2,1)   (3,1)
+  ///           1       0      -1      -2
+  ///             (0,0)   (1,0)   (2,0)   (3,0)
+  ///               0      -1      -2      -3
+  ///```
+  pub const fn xy<const N: usize>(&self) -> u32 {
+    self.y() + Self::xy_offset::<N>() - self.x()
   }
 
   /// Returns the underlying representation of the `PackedIdx` as a `u8`.

--- a/onoro_impl/src/packed_idx.rs
+++ b/onoro_impl/src/packed_idx.rs
@@ -15,6 +15,7 @@ pub struct PackedIdx {
 }
 
 impl PackedIdx {
+  /// An offset to apply to (y - x) so it is never negative.
   pub const fn xy_offset<const N: usize>() -> u32 {
     N as u32
   }

--- a/onoro_impl/src/packed_idx.rs
+++ b/onoro_impl/src/packed_idx.rs
@@ -47,7 +47,7 @@ impl PackedIdx {
   /// the x- and y-axes. This is normalized such that any PackedIdx will return
   /// a positive value.
   ///
-  ///```
+  ///```text
   /// (0,3)   (1,3)   (2,3)   (3,3)
   ///   3       2       1       0
   ///     (0,2)   (1,2)   (2,2)   (3,2)

--- a/onoro_impl/src/util.rs
+++ b/onoro_impl/src/util.rs
@@ -61,23 +61,6 @@ define_cmp!(max_i16, min_i16, i16);
 define_cmp!(max_i32, min_i32, i32);
 define_cmp!(max_i64, min_i64, i64);
 
-pub trait IterOnes {
-  /// Given an integer, returns an iterator over the bit indices with ones.
-  fn iter_ones(self) -> impl Iterator<Item = u32>;
-}
-
-impl<I: PrimInt> IterOnes for I {
-  fn iter_ones(self) -> impl Iterator<Item = u32> {
-    std::iter::once(()).cycle().scan(self, |state, _| {
-      (*state != I::zero()).then(|| {
-        let bit_index = state.trailing_zeros();
-        *state = *state & (*state - I::one());
-        bit_index
-      })
-    })
-  }
-}
-
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct MinAndMax<I: PrimInt> {
   min: I,
@@ -466,7 +449,7 @@ mod tests {
         CoordLimits::new(
           MinAndMax::new(1, 1),
           MinAndMax::new(1, 1),
-          MinAndMax::new(0xf, 0xf),
+          MinAndMax::new(PackedIdx::xy_offset::<1>(), PackedIdx::xy_offset::<1>()),
         ),
       ),
       (
@@ -474,7 +457,7 @@ mod tests {
         CoordLimits::new(
           MinAndMax::new(1, 3),
           MinAndMax::new(1, 5),
-          MinAndMax::new(11, 16),
+          MinAndMax::new(PackedIdx::xy_offset::<16>() - 1, PackedIdx::xy_offset::<16>() + 4),
         ),
       ),
     )]

--- a/onoro_impl/src/util.rs
+++ b/onoro_impl/src/util.rs
@@ -279,8 +279,8 @@ impl CoordLimits {
 #[inline]
 #[target_feature(enable = "ssse3")]
 fn packed_positions_coord_limits_sse3(pawn_poses: &[PackedIdx]) -> CoordLimits {
-  debug_assert_eq!(pawn_poses.len(), 16);
   const N: usize = 16;
+  debug_assert_eq!(pawn_poses.len(), N);
 
   let min_max_ignore_zero = |vec: __m128i, zeros: __m128i| -> MinAndMax<u32> {
     let min_vec = _mm_or_si128(vec, zeros);


### PR DESCRIPTION
This comes with a small performance cost, but is required for phase 2.

```
Benchmarking find moves phase 1/find moves phase 1 after 4 moves: Collecting 100 samples in estimated 21.993 s (56k iterations
find moves phase 1/find moves phase 1 after 4 moves
                        time:   [394.07 µs 394.13 µs 394.20 µs]
                        thrpt:  [25.368 Melem/s 25.372 Melem/s 25.376 Melem/s]
                 change:
                        time:   [+5.9740% +6.0560% +6.1399%] (p = 0.00 < 0.05)
                        thrpt:  [−5.7847% −5.7102% −5.6372%]
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe
Benchmarking find moves phase 1/find moves phase 1 after 8 moves: Collecting 100 samples in estimated 22.215 s (40k iterations
find moves phase 1/find moves phase 1 after 8 moves
                        time:   [549.80 µs 549.99 µs 550.16 µs]
                        thrpt:  [18.176 Melem/s 18.182 Melem/s 18.188 Melem/s]
                 change:
                        time:   [+0.5618% +0.6450% +0.7273%] (p = 0.00 < 0.05)
                        thrpt:  [−0.7220% −0.6409% −0.5587%]
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe
Benchmarking find moves phase 1/find moves phase 1 after 12 moves: Collecting 100 samples in estimated 23.628 s (30k iteration
find moves phase 1/find moves phase 1 after 12 moves
                        time:   [778.87 µs 779.06 µs 779.25 µs]
                        thrpt:  [12.833 Melem/s 12.836 Melem/s 12.839 Melem/s]
                 change:
                        time:   [+5.8211% +5.8838% +5.9453%] (p = 0.00 < 0.05)
                        thrpt:  [−5.6117% −5.5568% −5.5009%]
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  6 (6.00%) high mild
  1 (1.00%) high severe
```