### PR TITLE
Do 2-neighbor check in bitmasks for p1 move gen

### DIFF
--- a/onoro_impl/src/board_vec_indexer.rs
+++ b/onoro_impl/src/board_vec_indexer.rs
@@ -2,8 +2,8 @@ use num_traits::PrimInt;
 use onoro::hex_pos::HexPos;
 
 use crate::{
+  util::{bits_with_at_least_two_set_from_6, CoordLimits, MinAndMax},
   FilterNullPackedIdx, PackedIdx,
-  util::{CoordLimits, MinAndMax},
 };
 
 /// The choice of basis to use for the minimum bounding parallelogram of the
@@ -164,10 +164,10 @@ impl BoardVecIndexer {
     self.pos_from_coords((c1, c2))
   }
 
-  /// Builds both the board bitvec and neighbor candidates. The board bitvec
-  /// has a 1 in each index corresponding to an occupied tile, and the neighbor
-  /// candidates have a 1 in each index corresponding to an empty neighbor of
-  /// any pawn.
+  /// Builds both the board bitvec and eligible neighbors. The board bitvec has
+  /// a 1 in each index corresponding to an occupied tile, and the eligible
+  /// neighbors have a 1 in each index corresponding to an empty space with at
+  /// least 2 neighbors.
   pub fn build_bitvecs<I: PrimInt>(&self, pawn_poses: &[PackedIdx]) -> (I, I) {
     let width = self.width as u32;
 
@@ -183,14 +183,16 @@ impl BoardVecIndexer {
     // All neighbors are -(width+1), -width, -1, +1, +width, +(width+1) in
     // index space.
     let width = width as usize;
-    let neighbor_candidates = (board >> (width + 1))
-      | (board >> width)
-      | (board >> 1)
-      | (board << 1)
-      | (board << width)
-      | (board << (width + 1));
+    let eligible_neighbors = bits_with_at_least_two_set_from_6(
+      board >> 1,
+      board << 1,
+      board >> width,
+      board << width,
+      board >> (width + 1),
+      board << (width + 1),
+    );
 
-    (board, neighbor_candidates & !board)
+    (board, eligible_neighbors & !board)
   }
 
   /// Constructs a mask of the 6 neighbors of a tile at the given bitvector
@@ -210,9 +212,9 @@ impl BoardVecIndexer {
 mod tests {
   use std::fmt::Debug;
 
-  use onoro::{OnoroIndex, hex_pos::HexPosOffset};
+  use onoro::{hex_pos::HexPosOffset, OnoroIndex};
 
-  use crate::{PackedIdx, util::packed_positions_coord_limits};
+  use crate::{util::packed_positions_coord_limits, PackedIdx};
 
   use super::*;
 

--- a/onoro_impl/src/p1_move_gen.rs
+++ b/onoro_impl/src/p1_move_gen.rs
@@ -3,10 +3,10 @@ use num_traits::{PrimInt, Unsigned};
 use onoro::{abstract_game::GameMoveIterator, hex_pos::HexPos};
 
 use crate::{
-  Move, OnoroImpl, PackedIdx,
-  board_vec_indexer::{Basis, BoardVecIndexer, DetermineBasisOutput, determine_basis},
+  board_vec_indexer::{determine_basis, Basis, BoardVecIndexer, DetermineBasisOutput},
   num_iter::IterOnes,
   util::{likely, packed_positions_coord_limits},
+  Move, OnoroImpl, PackedIdx,
 };
 
 struct Impl<I> {
@@ -15,9 +15,9 @@ struct Impl<I> {
   /// empty tiles so that `board_vec` and `neighbor_candidates` can use the
   /// same indexer.
   board_vec: I,
-  /// A bitvector of all tiles with at least one pawn neighbor which are not
+  /// A bitvector of all tiles with at least two pawn neighbors which are not
   /// occupied by a pawn already.
-  neighbor_candidates: I,
+  eligible_neighbors: I,
   indexer: BoardVecIndexer,
 }
 
@@ -31,31 +31,27 @@ impl<I: Unsigned + PrimInt> Impl<I> {
     pawn_poses: &[PackedIdx; N],
   ) -> Self {
     let indexer = BoardVecIndexer::new(basis, corner, width);
-    let (board_vec, neighbor_candidates) = indexer.build_bitvecs(pawn_poses);
+    let (board_vec, eligible_neighbors) = indexer.build_bitvecs(pawn_poses);
     Self {
       board_vec,
-      neighbor_candidates,
+      eligible_neighbors,
       indexer,
     }
   }
 
   fn next_internal(&mut self) -> Option<(usize, I)> {
-    let mut neighbor_candidates = self.neighbor_candidates;
-    while neighbor_candidates != I::zero() {
-      let index = neighbor_candidates.trailing_zeros() as usize;
-      neighbor_candidates = neighbor_candidates & (neighbor_candidates - I::one());
-
-      let neighbors_mask: I = self.indexer.neighbors_mask(index);
-      let neighbors_mask = neighbors_mask & self.board_vec;
-      if neighbors_mask.count_ones() >= 2 {
-        self.neighbor_candidates = neighbor_candidates;
-        return Some((index, neighbors_mask));
-      }
+    let mut eligible_neighbors = self.eligible_neighbors;
+    if eligible_neighbors == I::zero() {
+      return None;
     }
 
-    // No need to store neighbor_candidates again, since we typically don't
-    // call next() again after None is returned.
-    None
+    let index = eligible_neighbors.trailing_zeros() as usize;
+    eligible_neighbors = eligible_neighbors & (eligible_neighbors - I::one());
+
+    let neighbors_mask: I = self.indexer.neighbors_mask(index);
+    let neighbors_mask = neighbors_mask & self.board_vec;
+    self.eligible_neighbors = eligible_neighbors;
+    Some((index, neighbors_mask))
   }
 
   /// Finds the position of the next move we can make, or `None` if all moves
@@ -230,15 +226,15 @@ impl<const N: usize> GameMoveIterator for P1MoveGenerator<N> {
 #[cfg(test)]
 mod tests {
   use onoro::{
-    Onoro, abstract_game::GameMoveIterator, error::OnoroResult, hex_pos::HexPos,
-    test_util::BOARD_POSITIONS,
+    abstract_game::GameMoveIterator, error::OnoroResult, hex_pos::HexPos,
+    test_util::BOARD_POSITIONS, Onoro,
   };
   use rstest::rstest;
   use rstest_reuse::{apply, template};
 
   use crate::{
-    FilterNullPackedIdx, Onoro16, PackedIdx,
     p1_move_gen::{BoardVecIndexer, ImplContainer, P1MoveGenerator},
+    FilterNullPackedIdx, Onoro16, PackedIdx,
   };
 
   fn get_board_vec<const N: usize>(move_gen: &P1MoveGenerator<N>) -> u128 {
@@ -248,10 +244,10 @@ mod tests {
     }
   }
 
-  fn get_neighbor_candidates<const N: usize>(move_gen: &P1MoveGenerator<N>) -> u128 {
+  fn get_eligible_neighbors<const N: usize>(move_gen: &P1MoveGenerator<N>) -> u128 {
     match &move_gen.impl_container {
-      ImplContainer::Small(impl_) => impl_.neighbor_candidates as u128,
-      ImplContainer::Large(impl_) => impl_.neighbor_candidates,
+      ImplContainer::Small(impl_) => impl_.eligible_neighbors as u128,
+      ImplContainer::Large(impl_) => impl_.eligible_neighbors,
     }
   }
 
@@ -273,10 +269,11 @@ mod tests {
     neighbors
   }
 
-  /// Returns a mask of all tiles that are empty and adjacent to a pawn on the
-  /// board.
-  fn all_possible_neighbors(board_vec: u128, indexer: &BoardVecIndexer) -> u128 {
+  /// Returns a mask of all tiles that are empty and next to at least two
+  /// pawns.
+  fn all_eligible_neighbors(board_vec: u128, indexer: &BoardVecIndexer) -> u128 {
     let mut neighbors = 0;
+    let mut neighbors2 = 0;
     let mut temp_board = board_vec;
     while temp_board != 0 {
       let index = temp_board.trailing_zeros();
@@ -284,10 +281,12 @@ mod tests {
 
       let pos = indexer.pos_from_index(index);
 
-      neighbors |= neighbors_mask(pos, indexer);
+      let mask = neighbors_mask(pos, indexer);
+      neighbors2 |= neighbors & mask;
+      neighbors |= mask;
     }
 
-    neighbors & !board_vec
+    neighbors2 & !board_vec
   }
 
   #[template]
@@ -318,13 +317,13 @@ mod tests {
     let indexer = &move_gen.indexer();
 
     let board_vec = build_board_vec(onoro.pawn_poses(), indexer);
-    let neighbor_candidates = all_possible_neighbors(board_vec, indexer);
+    let neighbor_candidates = all_eligible_neighbors(board_vec, indexer);
 
     assert_eq!(
-      get_neighbor_candidates(&move_gen),
+      get_eligible_neighbors(&move_gen),
       neighbor_candidates,
       "{:#016x} vs. {:#016x}",
-      get_neighbor_candidates(&move_gen),
+      get_eligible_neighbors(&move_gen),
       neighbor_candidates
     );
   }

--- a/onoro_impl/src/util.rs
+++ b/onoro_impl/src/util.rs
@@ -431,9 +431,9 @@ mod tests {
   #[cfg(target_feature = "sse4.1")]
   use std::arch::x86_64::*;
 
+  use googletest::gtest;
   #[cfg(target_feature = "sse4.1")]
-  use googletest::{gtest, prelude::*};
-  #[cfg(target_feature = "sse4.1")]
+  use googletest::prelude::*;
   use itertools::Itertools;
   use rand::RngCore;
   #[cfg(target_feature = "sse4.1")]

--- a/onoro_impl/src/util.rs
+++ b/onoro_impl/src/util.rs
@@ -467,7 +467,7 @@ mod tests {
   fn test_bits_with_at_least_two_set_from_6() {
     let mut rng = StdRng::seed_from_u64(204351098394);
 
-    for _ in 0..1 {
+    for _ in 0..100 {
       let a = rng.next_u64();
       let b = rng.next_u64();
       let c = rng.next_u64();

--- a/onoro_impl/src/util.rs
+++ b/onoro_impl/src/util.rs
@@ -102,6 +102,18 @@ impl<I: PrimInt> Default for MinAndMax<I> {
   }
 }
 
+/// Given a set of 3 integers, returns a u64 mask with a 1 in each bit having
+/// at least 2 values in the list with bits set in that position.
+fn bits_with_at_least_two_set_from_3<I: PrimInt>(a: I, b: I, c: I) -> I {
+  (a & b) | ((a ^ b) & c)
+}
+
+/// Given a set of 6 integers, returns a u64 mask with a 1 in each bit having
+/// at least 2 values in the list with bits set in that position.
+pub fn bits_with_at_least_two_set_from_6<I: PrimInt>(a: I, b: I, c: I, d: I, e: I, f: I) -> I {
+  (a & b) | (c & d) | (e & f) | bits_with_at_least_two_set_from_3(a ^ b, c ^ d, e ^ f)
+}
+
 pub trait MM128Iter {
   /// Iterates over the epi16 lanes of the register.
   fn iter_epi16(self) -> impl Iterator<Item = i16>;
@@ -423,6 +435,7 @@ mod tests {
   use googletest::{gtest, prelude::*};
   #[cfg(target_feature = "sse4.1")]
   use itertools::Itertools;
+  use rand::RngCore;
   #[cfg(target_feature = "sse4.1")]
   use rand::{rngs::StdRng, Rng, SeedableRng};
   use rstest::rstest;
@@ -439,6 +452,34 @@ mod tests {
     },
     PackedIdx,
   };
+
+  use super::bits_with_at_least_two_set_from_6;
+
+  fn bits_with_at_least_two_set_from_6_slow(a: u64, b: u64, c: u64, d: u64, e: u64, f: u64) -> u64 {
+    [a, b, c, d, e, f]
+      .iter()
+      .tuple_combinations()
+      .map(|(a, b)| a & b)
+      .fold(0, |acc, v| acc | v)
+  }
+
+  #[gtest]
+  fn test_bits_with_at_least_two_set_from_6() {
+    let mut rng = StdRng::seed_from_u64(204351098394);
+
+    for _ in 0..1 {
+      let a = rng.next_u64();
+      let b = rng.next_u64();
+      let c = rng.next_u64();
+      let d = rng.next_u64();
+      let e = rng.next_u64();
+      let f = rng.next_u64();
+
+      let actual = bits_with_at_least_two_set_from_6(a, b, c, d, e, f);
+      let expected = bits_with_at_least_two_set_from_6_slow(a, b, c, d, e, f);
+      assert_eq!(actual, expected);
+    }
+  }
 
   #[cfg(target_feature = "sse4.1")]
   #[target_feature(enable = "sse4.1")]

--- a/onoro_impl/src/util.rs
+++ b/onoro_impl/src/util.rs
@@ -435,9 +435,9 @@ mod tests {
   #[cfg(target_feature = "sse4.1")]
   use googletest::prelude::*;
   use itertools::Itertools;
-  use rand::RngCore;
   #[cfg(target_feature = "sse4.1")]
-  use rand::{rngs::StdRng, Rng, SeedableRng};
+  use rand::Rng;
+  use rand::{rngs::StdRng, RngCore, SeedableRng};
   use rstest::rstest;
   use rstest_reuse::{apply, template};
 


### PR DESCRIPTION
```
find moves phase 1/find moves phase 1 after 4 moves
                        time:   [194.75 µs 194.86 µs 194.96 µs]
                        thrpt:  [51.292 Melem/s 51.320 Melem/s 51.347 Melem/s]
                 change:
                        time:   [−49.341% −49.084% −48.830%] (p = 0.00 < 0.05)
                        thrpt:  [+95.426% +96.403% +97.398%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low severe
  2 (2.00%) low mild
find moves phase 1/find moves phase 1 after 8 moves
                        time:   [255.37 µs 255.47 µs 255.58 µs]
                        thrpt:  [39.127 Melem/s 39.144 Melem/s 39.159 Melem/s]
                 change:
                        time:   [−52.771% −52.716% −52.661%] (p = 0.00 < 0.05)
                        thrpt:  [+111.24% +111.49% +111.73%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  2 (2.00%) high severe
find moves phase 1/find moves phase 1 after 12 moves
                        time:   [326.50 µs 326.64 µs 326.81 µs]
                        thrpt:  [30.598 Melem/s 30.614 Melem/s 30.628 Melem/s]
                 change:
                        time:   [−56.175% −56.096% −56.024%] (p = 0.00 < 0.05)
                        thrpt:  [+127.40% +127.77% +128.18%]
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  6 (6.00%) high mild
  1 (1.00%) high severe

find moves phase 2/find moves phase 2 after 13 moves
                        time:   [3.5678 ms 3.5684 ms 3.5692 ms]
                        thrpt:  [1.4009 Melem/s 1.4012 Melem/s 1.4014 Melem/s]
                 change:
                        time:   [−7.4220% −7.0330% −6.6647%] (p = 0.00 < 0.05)
                        thrpt:  [+7.1406% +7.5651% +8.0171%]
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  4 (4.00%) high severe
Benchmarking find moves phase 2/find moves phase 2 after 15 moves: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 20.0s. You may wish to increase target time to 21.5s, enable flat sampling, or reduce sample count to 60.
find moves phase 2/find moves phase 2 after 15 moves
                        time:   [4.2640 ms 4.2675 ms 4.2739 ms]
                        thrpt:  [1.1699 Melem/s 1.1716 Melem/s 1.1726 Melem/s]
                 change:
                        time:   [−6.0101% −5.7007% −5.3441%] (p = 0.00 < 0.05)
                        thrpt:  [+5.6458% +6.0453% +6.3944%]
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) high mild
  6 (6.00%) high severe
Benchmarking find moves phase 2/find moves phase 2 after 17 moves: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 20.0s. You may wish to increase target time to 24.1s, enable flat sampling, or reduce sample count to 60.
find moves phase 2/find moves phase 2 after 17 moves
                        time:   [4.7661 ms 4.7684 ms 4.7716 ms]
                        thrpt:  [1.0479 Melem/s 1.0486 Melem/s 1.0491 Melem/s]
                 change:
                        time:   [−5.9678% −5.9022% −5.8353%] (p = 0.00 < 0.05)
                        thrpt:  [+6.1969% +6.2724% +6.3466%]
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) high mild
  5 (5.00%) high severe
```